### PR TITLE
Add Homebrew, Pip & Hashicorp Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,30 @@ The following setup tasks should be performed or borne in mind before running th
 - Change into ansible dir: `cd ansible`
 - Run the playbook: `ansible-playbook --vault-password-file ~/.vaultpass.txt install.yml`
 
+## Manual Tasks Not Automated
+
+The following tasks are not automated and still need to be done manually:
+
+### Chrome Extensions
+
+Chrome extensions [can be implemented automatically](https://developer.chrome.com/docs/extensions/mv3/external_extensions/) by creating a JSON file of the extension id, e.g. `jpmkfafbacpgapdghgdpembnojdlgkdl.json` under one of the following locations:
+
+```
+~/Library/Application\ Support/Google/Chrome/Default/Extensions
+~/Library/Application\ Support/Google/Chrome/External\ Extensions/
+```
+
+Such a file would typically look like this:
+
+```
+$ cat jpmkfafbacpgapdghgdpembnojdlgkdl.json
+{
+    "external_update_url": "https://clients2.google.com/service/update2/crx"
+}
+```
+
+For reasons of simplicity and maintenance, this is better done manually.
+
 ## References
 
 - Big thanks to 

--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -51,6 +51,8 @@ homebrew_installed_packages:
   - jq
   - kubectl
   - pv
+  - rpm
+  - shellcheck
   - socat
   - tflint
   - tree

--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -62,6 +62,7 @@ homebrew_cask_apps:
   - android-file-transfer
   - citrix-workspace
   - docker
+  - fig
   - firefox
   - google-chrome
   - microsoft-office

--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -42,6 +42,7 @@ mas_installed_apps:
 
 # Packages to Install with Homebrew
 homebrew_installed_packages:
+  - azure-cli
   - bash     # Adds Bash v5 in /usr/local/bin
   - dockutil
   - ffmpeg
@@ -75,6 +76,10 @@ homebrew_cask_apps:
   - visual-studio-code
   - vlc
   - zoho-mail
+
+# PIP Packages
+pip_package_list:
+  - pywinrm
 
 dockitems_remove:
   - TV
@@ -112,9 +117,9 @@ dockitems_persist:
   - name: Signal
     path: "/Applications/Signal.app/"
     pos: 16
-  - name: Zoho Mail
-    path: "/Applications/Zoho Mail - Desktop.app/"
-    pos: 17
+  # - name: Zoho Mail
+  #   path: "/Applications/Zoho Mail - Desktop.app/"
+  #   pos: 17
   - name: Spotify
     path: "/Applications/Spotify.app/"
     pos: 18

--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -45,6 +45,7 @@ homebrew_installed_packages:
   - azure-cli
   - bash     # Adds Bash v5 in /usr/local/bin
   - dockutil
+  - exa
   - ffmpeg
   - gh
   - git-delta

--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -59,6 +59,7 @@ homebrew_installed_packages:
 
 # GUI Apps to Install with Homebrew
 homebrew_cask_apps:
+  - android-file-transfer
   - citrix-workspace
   - docker
   - firefox

--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -42,12 +42,15 @@ mas_installed_apps:
 
 # Packages to Install with Homebrew
 homebrew_installed_packages:
+  - bash     # Adds Bash v5 in /usr/local/bin
   - dockutil
   - ffmpeg
   - gh
   - git-delta
+  - jq
   - kubectl
   - pv
+  - socat
   - tflint
   # - vagrant
   - youtube-dl

--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -53,6 +53,7 @@ homebrew_installed_packages:
   - pv
   - socat
   - tflint
+  - tree
   # - vagrant
   - youtube-dl
 
@@ -79,7 +80,9 @@ homebrew_cask_apps:
 
 # PIP Packages
 pip_package_list:
+  - hvac    # Hashicorp Vault module for Ansible
   - pywinrm
+  - spotdl
 
 dockitems_remove:
   - TV

--- a/ansible/roles/shell/tasks/main.yml
+++ b/ansible/roles/shell/tasks/main.yml
@@ -54,23 +54,23 @@
   loop: "{{ dirs_under_documents }}"
 
 # Download Hashicorp Tools
-- name: 'Download Hashicorp Tool Binaries'
-  get_url: 
-    url: "{{ item }}"
-    dest: ~/bin
-  loop: "{{ hashicorp_binaries }}"
+# - name: 'Download Hashicorp Tool Binaries'
+#   get_url: 
+#     url: "{{ item }}"
+#     dest: ~/bin
+#   loop: "{{ hashicorp_binaries }}"
 
-- name: 'Unzip Hashicorp Tool Binaries'
-  unarchive: 
-    src: "~/bin/{{ item }}"
-    dest: ~/bin
-  loop: "{{ hashicorp_binaries | map('basename') | list }}"
+# - name: 'Unzip Hashicorp Tool Binaries'
+#   unarchive: 
+#     src: "~/bin/{{ item }}"
+#     dest: ~/bin
+#   loop: "{{ hashicorp_binaries | map('basename') | list }}"
 
-- name: 'Remove Hashicorp Zip Files'
-  file:
-    path: "~/bin/{{ item }}"
-    state: absent
-  loop: "{{ hashicorp_binaries | map('basename') | list }}"
+# - name: 'Remove Hashicorp Zip Files'
+#   file:
+#     path: "~/bin/{{ item }}"
+#     state: absent
+#   loop: "{{ hashicorp_binaries | map('basename') | list }}"
 
 # Create Link for Visual Studio Code Binary
 - name: 'Create Link to VSCode Binary'
@@ -97,6 +97,12 @@
 - name: 'Install AWS CLI v2'
   shell: "{{ item }}"
   loop:
-    - curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
-    - installer -pkg AWSCLIV2.pkg -target /
+    - curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "/tmp/AWSCLIV2.pkg"
+    - installer -pkg /tmp/AWSCLIV2.pkg -target /
   become: true
+
+# Install pip Packages
+- name: 'Install pip Packages'
+  pip:
+    name: "{{ item }}"
+  loop: "{{ pip_package_list }}"

--- a/ansible/roles/shell/tasks/main.yml
+++ b/ansible/roles/shell/tasks/main.yml
@@ -78,3 +78,25 @@
     src: '/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code'
     dest: "{{ home_dir_path }}/bin/code"
     state: link
+
+# Create Link for Bash v5 & Add to /etc/shells
+- name: 'Create Link to Bash Binary to Override /bin/bash (v3)'
+  file:
+    src: '/opt/homebrew/Cellar/bash/5.1.16/bin/bash'
+    dest: /usr/local/bin/bash
+    state: link
+  become: yes
+
+- name: 'Add Bash (v5) to /etc/shells'
+  lineinfile:
+    path: /etc/shells
+    line: '/usr/local/bin/bash'
+  become: yes
+
+# Install AWS CLI v2
+- name: 'Install AWS CLI v2'
+  shell: "{{ item }}"
+  loop:
+    - curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "AWSCLIV2.pkg"
+    - installer -pkg AWSCLIV2.pkg -target /
+  become: true


### PR DESCRIPTION
# First Major PR

## Changes

- New Homebrew packages added to install
- New Pip packages added to install
- Tasks added to download Hashicorp binaries (note the specific versions)
- Override version 3 of /bin/bash in order to use v5 from Homebrew
- Install AWS CLI v2