### PR TITLE
Install: k9s and pre-commit (and disable taps check)

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -51,11 +51,13 @@ homebrew_installed_packages:
   - gh
   - git-delta
   - jq
+  - k9s
   - kubectl
   - libomp # for OpenBB
   - mkdocs
   - nmap
   - node
+  - pre-commit
   - pstree
   - pv
   - shellcheck

--- a/ansible/roles/homebrew/defaults/main.yml
+++ b/ansible/roles/homebrew/defaults/main.yml
@@ -12,8 +12,8 @@ homebrew_uninstalled_packages: []
 homebrew_upgrade_all_packages: false
 # homebrew_upgrade_all_packages: true
 
-homebrew_taps:
-  - homebrew/core
+# homebrew_taps:
+  # - homebrew/core
 
 homebrew_cask_apps: []
 

--- a/ansible/roles/homebrew/tasks/main.yml
+++ b/ansible/roles/homebrew/tasks/main.yml
@@ -109,12 +109,12 @@
       check_mode: false
 
     # Tap.
-    - name: Ensure configured taps are tapped.
-      homebrew_tap:
-        tap: '{{ item.name | default(item) }}'
-        url: '{{ item.url | default(omit) }}'
-        state: present
-      loop: "{{ homebrew_taps }}"
+    # - name: Ensure configured taps are tapped.
+    #   homebrew_tap:
+    #     tap: '{{ item.name | default(item) }}'
+    #     url: '{{ item.url | default(omit) }}'
+    #     state: present
+    #   loop: "{{ homebrew_taps }}"
 
     # Brew.
     - name: Ensure blacklisted homebrew packages are not installed.


### PR DESCRIPTION
Install two Homebrew utils:

- k9s
- pre-commit

Disable the task to test that taps are tapped after getting the following error:

``` shell
TASK [homebrew : Ensure configured taps are tapped.] *************************************************************************************************************************************************************************************************************************************************************
failed: [localhost] (item=homebrew/core) => changed=false 
  ansible_loop_var: item
  item: homebrew/core
  msg: |-
    added: 0, unchanged: 0, error: failed to tap: homebrew/core due to Running `brew update --auto-update`...
    ==> Homebrew collects anonymous analytics.
    Read the analytics documentation (and how to opt-out) here:
      https://docs.brew.sh/Analytics
    No analytics have been recorded yet (nor will be during this `brew` run).
  
    ==> Auto-updated Homebrew!
    Updated 2 taps (homebrew/core and homebrew/cask).
    ==> New Formulae
    actions-batch
    ansible-creator
    appwrite
    asmfmt
    autobrr
    autotrace
...
...
...
    zotero@beta
    zulu@11
    zulu@17
    zulu@21
    zulu@8
    ==> Deleted Installed Formulae
    python-brotli
    python-click
    python-distlib
    python-filelock
    python-markupsafe
    python-platformdirs
  
    You have 101 outdated formulae and 3 outdated casks installed.
  
    Error: Tapping homebrew/core is no longer typically necessary.
    Add --force if you are sure you need it for contributing to Homebrew.
```